### PR TITLE
Do not let whitelist() reclassify SKIP results as OK (#21)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
   consequently skipped (#15).
 - Document workaround for development with `devtools` (#19; thanks to @llrs
   for reporting).
+- Fix `whitelist()` reclassifying a skipped result (`SKIP`) as `OK` when a
+  supplied pattern happened to match the skip message (#21).
 
 # CBTF 0.7.0 (2026-07-03)
 

--- a/R/fuzz.R
+++ b/R/fuzz.R
@@ -361,9 +361,12 @@ whitelist <- function(object, patterns) {
   joined_patterns <- paste0(patterns, collapse = "|")
   joined_patterns <- gsub("^\\|", "", joined_patterns) # remove extra |
 
-  ## apply the new whitelist patterns to errors and warnings
+  ## apply the new whitelist patterns to errors and warnings, but never to
+  ## skipped results: the guard must test the result status (`res`), not the
+  ## message text, otherwise a pattern matching a "SKIP" message reclassifies
+  ## the skipped result as "OK" (#21).
   object$runs <- lapply(object$runs, function(x) {
-    x$res[grepl(joined_patterns, x$msg) & x$msg != "SKIP"] <- "OK"
+    x$res[grepl(joined_patterns, x$msg) & x$res != "SKIP"] <- "OK"
     x
   })
   object$ignore_patterns <- setdiff(c(object$ignore_patterns, patterns), "")

--- a/tests/testthat/test_fuzz.R
+++ b/tests/testthat/test_fuzz.R
@@ -349,6 +349,23 @@ test_that("whitelist", {
                ignore_patterns)
 })
 
+test_that("whitelist does not turn a SKIP into an OK (#21)", {
+  testthat::skip_on_cran()
+
+  ## a function that cannot be found produces a SKIP result whose message
+  ## ("Object not found in the ... namespace") may itself match a pattern the
+  ## user passes to whitelist(). Whitelisting must never reclassify a skipped
+  ## result as OK (reported by an R Journal referee, #21).
+  SW({
+  res <- fuzz(".not_found_fun.", list(NULL))
+  })
+  expect_skip_reason(res, "Object not found in the global namespace")
+
+  res.new <- whitelist(res, "not found")
+  expect_equal(res.new$runs[[1]]$res, "SKIP")
+  expect_equal(res.new$runs[[1]]$msg, "Object not found in the global namespace")
+})
+
 test_that("get_exported_functions", {
   testthat::skip_on_cran()
 


### PR DESCRIPTION
## Fix `whitelist()` turning `SKIP` results into `OK` (#21)

Fixes #21.

### Problem
`whitelist()` guards skipped results so they are never whitelisted, but the
guard tested the **message** column:

```r
x$res[grepl(joined_patterns, x$msg) & x$msg != "SKIP"] <- "OK"
```

A skip message is never the literal string `"SKIP"` (it is e.g.
`"Object not found in the global namespace"`), so `x$msg != "SKIP"` is always
`TRUE` and the guard never fires. Any pattern that matches a skip message
therefore reclassifies the `SKIP` result as `OK` — exactly the referee's case:

```r
res <- fuzz("inexistent")            # [ FAIL 0 | WARN 0 | SKIP 95 | OK 0 ]
whitelist(res, "Object not found")   # [ FAIL 0 | WARN 0 | SKIP 0  | OK 95 ]  # wrong
```

### Fix
Test the **result status** column instead:

```r
x$res[grepl(joined_patterns, x$msg) & x$res != "SKIP"] <- "OK"
```

Genuine skips are now preserved, while matching `WARN`/`FAIL` results are still
whitelisted to `OK` as before. One-token change; no behavioural change for any
non-`SKIP` result.

### Test
Adds `tests/testthat/test_fuzz.R` → *"whitelist does not turn a SKIP into an OK
(#21)"*: fuzz a not-found function (a `SKIP`), then `whitelist(res, "not found")`
and assert the result stays `SKIP`. It **fails on the current code** and
**passes with this change**.

Also adds a `NEWS.md` entry.
